### PR TITLE
Removed .env.example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,4 +11,3 @@ storage/
 .env.*.php
 .env.php
 .env
-.env.example


### PR DESCRIPTION
Removed `.env.example` from `.gitignore`, because example of configuration should be in repository
